### PR TITLE
Fix Eclipse Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Please ensure you are using the correct version of MixinGradle for your ForgeGra
  apply plugin: 'org.spongepowered.mixin'
  ```
  
+If using Eclipse, you should also enable the Eclipse APT plugin to receive annotation processor support within Eclipse:  
+  
+ ```groovy
+ apply plugin: 'com.diffplug.eclipse.apt'
+ ```
+  
 3. Create your `mixin` block, specify which sourceSets to process and provide refmap resource names for each one, the generated refmap will be added to the compiler task outputs automatically.
  
  ```groovy


### PR DESCRIPTION
This PR Fixes #40 and is a rebased version of #34 based on a commit by @CreativeMD (which is then based on a version by @DarkShadow44) https://github.com/CreativeMD/MixinGradle/commit/49453a0ba10258390879795316b8d3fd2fe914a5

It is recommended that eclipse users also apply the diffplug plugin so that the annotation processor can work correctly:
`id 'com.diffplug.eclipse.apt' version '3.42.2'`